### PR TITLE
feat: パーソナライズしたページ埋め込みコンポーネントを作成

### DIFF
--- a/src/api/personalized-embed.jsx
+++ b/src/api/personalized-embed.jsx
@@ -31,8 +31,8 @@ function PersonalizedPageEmbed(element) {
     if (!file) throw new Error("No Matching TFile");
 
     dc.useEffect(() => {
+        if (element.value("status") === pageStatus) return;
         dc.app.fileManager.processFrontMatter(file, (frontmatter) => {
-            if (frontmatter.status === pageStatus) return;
             frontmatter.status = pageStatus;
         });
     }, [pageStatus, file]);

--- a/src/api/personalized-embed.jsx
+++ b/src/api/personalized-embed.jsx
@@ -12,6 +12,8 @@ function PersonalizedPageEmbed(element) {
         throw new Error("Does not have created property");
     }
 
+    // コンポーネントの初回作成時に一意で更新されないUUIDを付与
+    // キーなど一意性が必要な場所で用いる
     const uuid = dc.useMemo(() => self.crypto.randomUUID(), []);
 
     const path = element.$file;
@@ -20,6 +22,8 @@ function PersonalizedPageEmbed(element) {
 
     const workspace = dc.app.workspace;
     if (!workspace) throw new Error("No workspace found");
+
+    // タイムスタンプをクリックした際に埋め込み元のファイルにジャンプするイベントハンドラー
     const onTimestampClick = dc.useCallback(
         (event) => workspace.openLinkText(path, path, event.shiftKey),
         [path, workspace]
@@ -31,10 +35,12 @@ function PersonalizedPageEmbed(element) {
     const file = dc.core.vault.getFileByPath(path);
     if (!file) throw new Error("No Matching TFile");
 
+    // elementのステータスプロパティが外部から修正された場合に状態を更新する
     dc.useEffect(() => {
         setPageStatus(elementStatus ?? "tweet");
     }, [elementStatus]);
 
+    // ラジオボタンを介して状態が変更された際に、実際にファイルのプロパティを更新する
     dc.useEffect(() => {
         if (elementStatus === pageStatus) return;
         dc.app.fileManager.processFrontMatter(file, (frontmatter) => {

--- a/src/api/personalized-embed.jsx
+++ b/src/api/personalized-embed.jsx
@@ -23,9 +23,32 @@ function PersonalizedPageEmbed(element) {
         [path, workspace]
     );
 
+    const inputName = dc.useMemo(() => {
+        return `page-type-${self.crypto.randomUUID()}`;
+    }, []);
+
     return (
         <div className="personalized-embed">
-            <h2 onClick={onTimestampClick}>{created.toFormat("HH:mm:ss")}</h2>
+            <div className="personalized-embed-header">
+                <h2 onClick={onTimestampClick}>{created.toFormat("HH:mm:ss")}</h2>
+                <fieldset>
+                    <input type="radio" id="choice-tweet" name={inputName} value="tweet" />
+                    <label for="choice-tweet">🕊</label>
+
+                    <input type="radio" id="choice-now" name={inputName} value="now" />
+                    <label for="choice-now">🎯</label>
+
+                    <input type="radio" id="choice-task" name={inputName} value="task" />
+                    <label for="choice-task">📋</label>
+
+                    <input type="radio" id="choice-later" name={inputName} value="later" />
+                    <label for="choice-later">⌛</label>
+
+                    <input type="radio" id="choice-done" name={inputName} value="done" checked={true} />
+                    <label for="choice-done">✅</label>
+                </fieldset>
+            </div>
+
             <dc.SpanEmbed path={path} start={start} end={end} showExplain={false} />
         </div>
     );

--- a/src/api/personalized-embed.jsx
+++ b/src/api/personalized-embed.jsx
@@ -1,0 +1,22 @@
+function PersonalizedPageEmbed(element) {
+    if (!element.$types.contains("page")) {
+        throw new Error("Not a page");
+    }
+    if (!element.$file) {
+        throw new Error("Does not have file property");
+    }
+    if (!element.$position) {
+        throw new Error("Does not have position property");
+    }
+    if (!element.value("created")) {
+        throw new Error("Does not have created property");
+    }
+    const { start, end } = element.$position;
+    const created = element.value("created");
+    return (
+        <div className="personalized-embed">
+            <h2>{created.toFormat("HH:mm:ss")}</h2>
+            <dc.SpanEmbed path={element.$file} start={start} end={end} showExplain={false} />
+        </div>
+    );
+}

--- a/src/api/personalized-embed.jsx
+++ b/src/api/personalized-embed.jsx
@@ -25,17 +25,18 @@ function PersonalizedPageEmbed(element) {
         [path, workspace]
     );
 
+    const elementStatus = element.value("status");
     const inputName = `page-status-${uuid}`;
-    const [pageStatus, setPageStatus] = dc.useState(() => element.value("status") ?? "tweet");
+    const [pageStatus, setPageStatus] = dc.useState(() => elementStatus ?? "tweet");
     const file = dc.core.vault.getFileByPath(path);
     if (!file) throw new Error("No Matching TFile");
 
     dc.useEffect(() => {
-        if (element.value("status") === pageStatus) return;
+        if (elementStatus === pageStatus) return;
         dc.app.fileManager.processFrontMatter(file, (frontmatter) => {
             frontmatter.status = pageStatus;
         });
-    }, [pageStatus, file]);
+    }, [pageStatus, file, elementStatus]);
 
     return (
         <div className="personalized-embed" key={uuid}>

--- a/src/api/personalized-embed.jsx
+++ b/src/api/personalized-embed.jsx
@@ -24,17 +24,17 @@ function PersonalizedPageEmbed(element) {
     );
 
     const inputName = dc.useMemo(() => {
-        return `page-type-${self.crypto.randomUUID()}`;
+        return `page-status-${self.crypto.randomUUID()}`;
     }, []);
-    const [pageType, setPageType] = dc.useState(() => element.value("status") ?? "tweet");
+    const [pageStatus, setPageStatus] = dc.useState(() => element.value("status") ?? "tweet");
     const file = dc.core.vault.getFileByPath(path);
     if (!file) throw new Error("No Matching TFile");
 
     dc.useEffect(() => {
         dc.app.fileManager.processFrontMatter(file, (frontmatter) => {
-            frontmatter.status = pageType;
+            frontmatter.status = pageStatus;
         });
-    }, [pageType]);
+    }, [pageStatus]);
 
     return (
         <div className="personalized-embed">
@@ -46,8 +46,8 @@ function PersonalizedPageEmbed(element) {
                         id="choice-tweet"
                         name={inputName}
                         value="tweet"
-                        checked={pageType === "tweet"}
-                        onChange={() => setPageType("tweet")}
+                        checked={pageStatus === "tweet"}
+                        onChange={() => setPageStatus("tweet")}
                     />
                     <label for="choice-tweet">🕊</label>
 
@@ -56,8 +56,8 @@ function PersonalizedPageEmbed(element) {
                         id="choice-now"
                         name={inputName}
                         value="now"
-                        checked={pageType === "now"}
-                        onChange={() => setPageType("now")}
+                        checked={pageStatus === "now"}
+                        onChange={() => setPageStatus("now")}
                     />
                     <label for="choice-now">🎯</label>
 
@@ -66,8 +66,8 @@ function PersonalizedPageEmbed(element) {
                         id="choice-task"
                         name={inputName}
                         value="task"
-                        checked={pageType === "task"}
-                        onChange={() => setPageType("task")}
+                        checked={pageStatus === "task"}
+                        onChange={() => setPageStatus("task")}
                     />
                     <label for="choice-task">📋</label>
 
@@ -76,8 +76,8 @@ function PersonalizedPageEmbed(element) {
                         id="choice-later"
                         name={inputName}
                         value="later"
-                        checked={pageType === "later"}
-                        onChange={() => setPageType("later")}
+                        checked={pageStatus === "later"}
+                        onChange={() => setPageStatus("later")}
                     />
                     <label for="choice-later">⌛</label>
 
@@ -86,8 +86,8 @@ function PersonalizedPageEmbed(element) {
                         id="choice-done"
                         name={inputName}
                         value="done"
-                        checked={pageType === "done"}
-                        onChange={() => setPageType("done")}
+                        checked={pageStatus === "done"}
+                        onChange={() => setPageStatus("done")}
                     />
                     <label for="choice-done">✅</label>
                 </fieldset>

--- a/src/api/personalized-embed.jsx
+++ b/src/api/personalized-embed.jsx
@@ -38,18 +38,20 @@ function PersonalizedPageEmbed(element) {
         });
     }, [pageStatus, file, elementStatus]);
 
+    const STATUS_OPTIONS = [
+        { value: "tweet", label: "🕊" },
+        { value: "now", label: "🎯" },
+        { value: "task", label: "📋" },
+        { value: "later", label: "⌛" },
+        { value: "done", label: "✅" },
+    ];
+
     return (
         <div className="personalized-embed" key={uuid}>
             <div className="personalized-embed-header">
                 <h2 onClick={onTimestampClick}>{created.toFormat("HH:mm:ss")}</h2>
                 <fieldset>
-                    {[
-                        { value: "tweet", label: "🕊" },
-                        { value: "now", label: "🎯" },
-                        { value: "task", label: "📋" },
-                        { value: "later", label: "⌛" },
-                        { value: "done", label: "✅" },
-                    ].map(({ value, label }) => (
+                    {STATUS_OPTIONS.map(({ value, label }) => (
                         <dc.preact.Fragment key={value}>
                             <input
                                 type="radio"

--- a/src/api/personalized-embed.jsx
+++ b/src/api/personalized-embed.jsx
@@ -23,6 +23,7 @@ function PersonalizedPageEmbed(element) {
         [path, workspace]
     );
 
+    const pageType = element.value("page-type") ?? "tweet";
     const inputName = dc.useMemo(() => {
         return `page-type-${self.crypto.randomUUID()}`;
     }, []);
@@ -32,19 +33,31 @@ function PersonalizedPageEmbed(element) {
             <div className="personalized-embed-header">
                 <h2 onClick={onTimestampClick}>{created.toFormat("HH:mm:ss")}</h2>
                 <fieldset>
-                    <input type="radio" id="choice-tweet" name={inputName} value="tweet" />
+                    <input
+                        type="radio"
+                        id="choice-tweet"
+                        name={inputName}
+                        value="tweet"
+                        checked={pageType === "tweet"}
+                    />
                     <label for="choice-tweet">🕊</label>
 
-                    <input type="radio" id="choice-now" name={inputName} value="now" />
+                    <input type="radio" id="choice-now" name={inputName} value="now" checked={pageType === "now"} />
                     <label for="choice-now">🎯</label>
 
-                    <input type="radio" id="choice-task" name={inputName} value="task" />
+                    <input type="radio" id="choice-task" name={inputName} value="task" checked={pageType === "task"} />
                     <label for="choice-task">📋</label>
 
-                    <input type="radio" id="choice-later" name={inputName} value="later" />
+                    <input
+                        type="radio"
+                        id="choice-later"
+                        name={inputName}
+                        value="later"
+                        checked={pageType === "later"}
+                    />
                     <label for="choice-later">⌛</label>
 
-                    <input type="radio" id="choice-done" name={inputName} value="done" checked={true} />
+                    <input type="radio" id="choice-done" name={inputName} value="done" checked={pageType === "done"} />
                     <label for="choice-done">✅</label>
                 </fieldset>
             </div>

--- a/src/api/personalized-embed.jsx
+++ b/src/api/personalized-embed.jsx
@@ -35,7 +35,7 @@ function PersonalizedPageEmbed(element) {
             if (frontmatter.status === pageStatus) return;
             frontmatter.status = pageStatus;
         });
-    }, [pageStatus]);
+    }, [pageStatus, file]);
 
     return (
         <div className="personalized-embed" key={uuid}>

--- a/src/api/personalized-embed.jsx
+++ b/src/api/personalized-embed.jsx
@@ -32,6 +32,10 @@ function PersonalizedPageEmbed(element) {
     if (!file) throw new Error("No Matching TFile");
 
     dc.useEffect(() => {
+        setPageStatus(elementStatus ?? "tweet");
+    }, [elementStatus]);
+
+    dc.useEffect(() => {
         if (elementStatus === pageStatus) return;
         dc.app.fileManager.processFrontMatter(file, (frontmatter) => {
             frontmatter.status = pageStatus;

--- a/src/api/personalized-embed.jsx
+++ b/src/api/personalized-embed.jsx
@@ -41,55 +41,25 @@ function PersonalizedPageEmbed(element) {
             <div className="personalized-embed-header">
                 <h2 onClick={onTimestampClick}>{created.toFormat("HH:mm:ss")}</h2>
                 <fieldset>
-                    <input
-                        type="radio"
-                        id="choice-tweet"
-                        name={inputName}
-                        value="tweet"
-                        checked={pageStatus === "tweet"}
-                        onChange={() => setPageStatus("tweet")}
-                    />
-                    <label for="choice-tweet">🕊</label>
-
-                    <input
-                        type="radio"
-                        id="choice-now"
-                        name={inputName}
-                        value="now"
-                        checked={pageStatus === "now"}
-                        onChange={() => setPageStatus("now")}
-                    />
-                    <label for="choice-now">🎯</label>
-
-                    <input
-                        type="radio"
-                        id="choice-task"
-                        name={inputName}
-                        value="task"
-                        checked={pageStatus === "task"}
-                        onChange={() => setPageStatus("task")}
-                    />
-                    <label for="choice-task">📋</label>
-
-                    <input
-                        type="radio"
-                        id="choice-later"
-                        name={inputName}
-                        value="later"
-                        checked={pageStatus === "later"}
-                        onChange={() => setPageStatus("later")}
-                    />
-                    <label for="choice-later">⌛</label>
-
-                    <input
-                        type="radio"
-                        id="choice-done"
-                        name={inputName}
-                        value="done"
-                        checked={pageStatus === "done"}
-                        onChange={() => setPageStatus("done")}
-                    />
-                    <label for="choice-done">✅</label>
+                    {[
+                        { value: "tweet", label: "🕊" },
+                        { value: "now", label: "🎯" },
+                        { value: "task", label: "📋" },
+                        { value: "later", label: "⌛" },
+                        { value: "done", label: "✅" },
+                    ].map(({ value, label }) => (
+                        <dc.preact.Fragment key={value}>
+                            <input
+                                type="radio"
+                                id={`choice-${value}`}
+                                name={inputName}
+                                value={value}
+                                checked={pageStatus === value}
+                                onChange={() => setPageStatus(value)}
+                            />
+                            <label htmlFor={`choice-${value}`}>{label}</label>
+                        </dc.preact.Fragment>
+                    ))}
                 </fieldset>
             </div>
 

--- a/src/api/personalized-embed.jsx
+++ b/src/api/personalized-embed.jsx
@@ -23,10 +23,18 @@ function PersonalizedPageEmbed(element) {
         [path, workspace]
     );
 
-    const pageType = element.value("page-type") ?? "tweet";
     const inputName = dc.useMemo(() => {
         return `page-type-${self.crypto.randomUUID()}`;
     }, []);
+    const [pageType, setPageType] = dc.useState(() => element.value("status") ?? "tweet");
+    const file = dc.core.vault.getFileByPath(path);
+    if (!file) throw new Error("No Matching TFile");
+
+    dc.useEffect(() => {
+        dc.app.fileManager.processFrontMatter(file, (frontmatter) => {
+            frontmatter.status = pageType;
+        });
+    }, [pageType]);
 
     return (
         <div className="personalized-embed">
@@ -39,13 +47,28 @@ function PersonalizedPageEmbed(element) {
                         name={inputName}
                         value="tweet"
                         checked={pageType === "tweet"}
+                        onChange={() => setPageType("tweet")}
                     />
                     <label for="choice-tweet">🕊</label>
 
-                    <input type="radio" id="choice-now" name={inputName} value="now" checked={pageType === "now"} />
+                    <input
+                        type="radio"
+                        id="choice-now"
+                        name={inputName}
+                        value="now"
+                        checked={pageType === "now"}
+                        onChange={() => setPageType("now")}
+                    />
                     <label for="choice-now">🎯</label>
 
-                    <input type="radio" id="choice-task" name={inputName} value="task" checked={pageType === "task"} />
+                    <input
+                        type="radio"
+                        id="choice-task"
+                        name={inputName}
+                        value="task"
+                        checked={pageType === "task"}
+                        onChange={() => setPageType("task")}
+                    />
                     <label for="choice-task">📋</label>
 
                     <input
@@ -54,10 +77,18 @@ function PersonalizedPageEmbed(element) {
                         name={inputName}
                         value="later"
                         checked={pageType === "later"}
+                        onChange={() => setPageType("later")}
                     />
                     <label for="choice-later">⌛</label>
 
-                    <input type="radio" id="choice-done" name={inputName} value="done" checked={pageType === "done"} />
+                    <input
+                        type="radio"
+                        id="choice-done"
+                        name={inputName}
+                        value="done"
+                        checked={pageType === "done"}
+                        onChange={() => setPageType("done")}
+                    />
                     <label for="choice-done">✅</label>
                 </fieldset>
             </div>

--- a/src/api/personalized-embed.jsx
+++ b/src/api/personalized-embed.jsx
@@ -12,6 +12,8 @@ function PersonalizedPageEmbed(element) {
         throw new Error("Does not have created property");
     }
 
+    const uuid = dc.useMemo(() => self.crypto.randomUUID(), []);
+
     const path = element.$file;
     const { start, end } = element.$position;
     const created = element.value("created");
@@ -23,9 +25,7 @@ function PersonalizedPageEmbed(element) {
         [path, workspace]
     );
 
-    const inputName = dc.useMemo(() => {
-        return `page-status-${self.crypto.randomUUID()}`;
-    }, []);
+    const inputName = `page-status-${uuid}`;
     const [pageStatus, setPageStatus] = dc.useState(() => element.value("status") ?? "tweet");
     const file = dc.core.vault.getFileByPath(path);
     if (!file) throw new Error("No Matching TFile");
@@ -38,7 +38,7 @@ function PersonalizedPageEmbed(element) {
     }, [pageStatus]);
 
     return (
-        <div className="personalized-embed">
+        <div className="personalized-embed" key={uuid}>
             <div className="personalized-embed-header">
                 <h2 onClick={onTimestampClick}>{created.toFormat("HH:mm:ss")}</h2>
                 <fieldset>

--- a/src/api/personalized-embed.jsx
+++ b/src/api/personalized-embed.jsx
@@ -32,6 +32,7 @@ function PersonalizedPageEmbed(element) {
 
     dc.useEffect(() => {
         dc.app.fileManager.processFrontMatter(file, (frontmatter) => {
+            if (frontmatter.status === pageStatus) return;
             frontmatter.status = pageStatus;
         });
     }, [pageStatus]);

--- a/src/api/personalized-embed.jsx
+++ b/src/api/personalized-embed.jsx
@@ -11,12 +11,22 @@ function PersonalizedPageEmbed(element) {
     if (!element.value("created")) {
         throw new Error("Does not have created property");
     }
+
+    const path = element.$file;
     const { start, end } = element.$position;
     const created = element.value("created");
+
+    const workspace = dc.app.workspace;
+    if (!workspace) throw new Error("No workspace found");
+    const onTimestampClick = dc.useCallback(
+        (event) => workspace.openLinkText(path, path, event.shiftKey),
+        [path, workspace]
+    );
+
     return (
         <div className="personalized-embed">
-            <h2>{created.toFormat("HH:mm:ss")}</h2>
-            <dc.SpanEmbed path={element.$file} start={start} end={end} showExplain={false} />
+            <h2 onClick={onTimestampClick}>{created.toFormat("HH:mm:ss")}</h2>
+            <dc.SpanEmbed path={path} start={start} end={end} showExplain={false} />
         </div>
     );
 }


### PR DESCRIPTION
最低限コピペすれば動くコンポーネントを作成

# 実装
- created プロパティを用いたタイムスタンプの表示
- タイムスタンプをクリックした際にオリジナルのファイルに飛ぶ機能
- ラジオボタンを介してつぶやきのステータスを各種タスクのステータスやつぶやきに変更できる機能

# 未実装
- スタイリング
- タスク表示用とタイムライン表示用の表示の変更
- できればビルドスクリプトを変更して、ビルドしたらoutにこのコンポーネントがひとつのビューになるように出力したい
