### PR TITLE
update: createdプロパティが見つからなかった場合は例外を投げる代わりに、空要素を返して表示されないようにした

### DIFF
--- a/src/personal_views/components/personalized-embed.jsx
+++ b/src/personal_views/components/personalized-embed.jsx
@@ -9,7 +9,7 @@ export function PersonalizedPageEmbed(element) {
         throw new Error("Does not have position property");
     }
     if (!element.value("created")) {
-        throw new Error("Does not have created property");
+        return <div />
     }
 
     // コンポーネントの初回作成時に一意で更新されないUUIDを付与


### PR DESCRIPTION
$typesや$file, $position などはObsidian Datacore によって自動的に生成されているのが保証されている。 また、要素のタイプがページであることもこのコンポーネントの前提条件である。
なのでこれらの検査に違反する場合に例外を投げることは正当化される。
一方でユーザー作成のcreatedプロパティが存在しないのは十分あり得ることであり、例外を投げるのはやり過ぎに感じた。 実際に自分も過去のファイルを対象にこのビューを使うと例外が投げられて不便だった.