### PR TITLE
feat: タスクのリストビューの作成

### DIFF
--- a/src/personal_views/task-list.jsx
+++ b/src/personal_views/task-list.jsx
@@ -19,9 +19,10 @@ export function View() {
     return taskOptions.map((option) => {
         const group = grouped.find(({ key, _ }) => key === option.value);
         if (!group) return <div />;
+
         const { key, rows } = group;
         return (
-            <div>
+            <div key={key}>
                 <h2>
                     {key.toUpperCase()}
                     {option.label}


### PR DESCRIPTION
自分の望む形でタスクを抽出しソートしたりグルーピングしたりして一覧表示するビューを作成
タスクを抽出したりグルーピングしたりする処理にパラメーターがハードコーディングされてるが、自分で使うようなので特に問題ない
ただその前処理部分がだいぶ長いので、各グループを描写するコンポーネントは別の関数に切り出しても良さそう

