### PR TITLE
change: ビューのビルドフォーマットをIIFEからESMに変更

### DIFF
--- a/src/personal_views/build.mjs
+++ b/src/personal_views/build.mjs
@@ -21,9 +21,9 @@ async function build(entryPoint, outFile) {
         bundle: true,
         minify: false,
         jsx: "preserve",
-        format: "iife",
-        globalName: "tempModule",
-        footer: { js: "return tempModule.View;" },
+        format: "esm",
+        treeShaking: false, // メインのView関数がexportされない場合は削除されてしまうのを阻止
+        footer: { js: "return View;" },
     });
 }
 

--- a/src/personal_views/task-list.jsx
+++ b/src/personal_views/task-list.jsx
@@ -1,7 +1,7 @@
 import { PersonalizedPageEmbed } from "./components/personalized-embed";
 import { STATUS_OPTIONS } from "./constants/status-options";
 
-export function View() {
+function View() {
     const currentFile = dc.useCurrentFile();
     const today = currentFile.$name;
     const query = `

--- a/src/personal_views/timeline.jsx
+++ b/src/personal_views/timeline.jsx
@@ -1,6 +1,6 @@
 import { PersonalizedPageEmbed } from "./components/personalized-embed";
 
-export function View() {
+function View() {
     const currentFile = dc.useCurrentFile();
     const today = currentFile.$name;
     const data = dc.useQuery(`@page and path("tweets/${today}")`);


### PR DESCRIPTION
従来のIIFEを使ったやり方は、ビルドに正規表現を用いずにfooterを追加するだけでObsidian Datacoreのビューとして有効なファイルを出力できることから採用した。 https://github.com/kamome283/personalized-datacore-embed-view/pull/3#discussion_r2324028527 
しかし今回ビューの定義ファイル中でexportをせずにツリーシェーキングを無効にすることで、同様に正規表現を用いずに有効なファイルを出力できるのではないかと考えた。 
この変更によって可読性の大幅な向上と自分が読んで理解できる安心感が高まるはず