### PR TITLE
update: タイムスタンプにCSSクラスをつけたうえで日付を表示するようにした

### DIFF
--- a/src/personal_views/components/personalized-embed.jsx
+++ b/src/personal_views/components/personalized-embed.jsx
@@ -52,7 +52,10 @@ export function PersonalizedPageEmbed(element) {
     return (
         <div className="personalized-embed" key={uuid}>
             <div className="personalized-embed-header">
-                <h2 onClick={onTimestampClick}>{created.toFormat("HH:mm:ss")}</h2>
+                <h2 onClick={onTimestampClick}>
+                    <span className="date">{created.toFormat("MM/dd")} </span>
+                    <span className="time">{created.toFormat("HH:mm:ss")}</span>
+                </h2>
                 <fieldset>
                     {STATUS_OPTIONS.map(({ value, label }) => (
                         <dc.preact.Fragment key={value}>


### PR DESCRIPTION
当初はパラメーターによってタイムスタンプの表示を変えることを考えたが、最終的に消費されるコンポーネントに渡す際にパラメーターを与えられないことを思い出した。 代替案として日付と時間にそれぞれ別のCSSクラスを当てた上で必要があればスタイルシートで表示非表示を変えてねというやり方で対処する方針にした