### PR TITLE
feat: DONE セクションを非表示にする

### DIFF
--- a/src/personal_views/task-list.jsx
+++ b/src/personal_views/task-list.jsx
@@ -1,6 +1,8 @@
 import { PersonalizedPageEmbed } from "./components/personalized-embed";
 import { STATUS_OPTIONS } from "./constants/status-options";
 
+const HIDE_DONE_SECTION = true;
+
 function View() {
     const currentFile = dc.useCurrentFile();
     const today = currentFile.$name;
@@ -15,7 +17,8 @@ function View() {
         return data.sort((e) => e.value("created")).groupBy((e) => e.value("status"));
     });
 
-    const taskOptions = STATUS_OPTIONS.slice(1);
+    // HIDE_DONE_SECTION が true ならば定数の最後のDONEも取り除き、 falseならば取り除かない
+    const taskOptions = STATUS_OPTIONS.slice(1, HIDE_DONE_SECTION ? -1 : undefined);
     return taskOptions.map((option) => {
         const group = grouped.find(({ key, _ }) => key === option.value);
         if (!group) return <div />;


### PR DESCRIPTION
あとで気が変わって表示したいなってなった時もすぐに戻せるように先頭のフラグで表示非表示を変えられるようにしている。
CSSクラスを与えることでスタイルシートから簡単に表示非表示を変えれるようにしようかとも考えたが、ループ内で分岐が必要になるのでちょっと面倒だなってなってしまった。 
表示非表示を頻繁に変えたいってなるようならスタイルシートで管理できるほうがいいかなとは思うけど、現時点ではそこまでは考えていない。