### PR TITLE
feat: 埋め込み部分をクリックしてもファイルに飛べるように変更

### DIFF
--- a/src/personal_views/components/personalized-embed.jsx
+++ b/src/personal_views/components/personalized-embed.jsx
@@ -26,7 +26,16 @@ export function PersonalizedPageEmbed(element) {
     if (!workspace) throw new Error("No workspace found");
 
     // クリックした際に埋め込み元のファイルにジャンプするイベントハンドラー
-    const jumpToFile = dc.useCallback((event) => workspace.openLinkText(path, path, event.shiftKey), [path, workspace]);
+    const jumpToFile = dc.useCallback(
+        (event) => {
+            // イベントの発生源がチェックボックスなら、ファイルへのジャンプを中止する
+            if (event.target.tagName === "INPUT" && event.target.type === "checkbox") {
+                return;
+            }
+            workspace.openLinkText(path, path, event.shiftKey);
+        },
+        [path, workspace]
+    );
 
     const status = element.value("status");
     const inputName = `page-status-${uuid}`;

--- a/src/personal_views/components/personalized-embed.jsx
+++ b/src/personal_views/components/personalized-embed.jsx
@@ -25,11 +25,8 @@ export function PersonalizedPageEmbed(element) {
     const workspace = dc.app.workspace;
     if (!workspace) throw new Error("No workspace found");
 
-    // タイムスタンプをクリックした際に埋め込み元のファイルにジャンプするイベントハンドラー
-    const onTimestampClick = dc.useCallback(
-        (event) => workspace.openLinkText(path, path, event.shiftKey),
-        [path, workspace]
-    );
+    // クリックした際に埋め込み元のファイルにジャンプするイベントハンドラー
+    const jumpToFile = dc.useCallback((event) => workspace.openLinkText(path, path, event.shiftKey), [path, workspace]);
 
     const status = element.value("status");
     const inputName = `page-status-${uuid}`;
@@ -52,7 +49,7 @@ export function PersonalizedPageEmbed(element) {
     return (
         <div className="personalized-embed" key={uuid}>
             <div className="personalized-embed-header">
-                <h2 onClick={onTimestampClick}>
+                <h2 onClick={jumpToFile}>
                     <span className="date">{created.toFormat("MM/dd")} </span>
                     <span className="time">{created.toFormat("HH:mm:ss")}</span>
                 </h2>

--- a/src/personal_views/components/personalized-embed.jsx
+++ b/src/personal_views/components/personalized-embed.jsx
@@ -29,7 +29,7 @@ export function PersonalizedPageEmbed(element) {
     const jumpToFile = dc.useCallback(
         (event) => {
             // イベントの発生源がチェックボックスなら、ファイルへのジャンプを中止する
-            if (event.target.tagName === "INPUT" && event.target.type === "checkbox") {
+            if (event.target.closest('a, button, input, select, textarea')) {
                 return;
             }
             workspace.openLinkText(path, path, event.shiftKey);

--- a/src/personal_views/components/personalized-embed.jsx
+++ b/src/personal_views/components/personalized-embed.jsx
@@ -70,7 +70,9 @@ export function PersonalizedPageEmbed(element) {
                 </fieldset>
             </div>
 
-            <dc.SpanEmbed path={path} start={start} end={end} showExplain={false} />
+            <div onClick={jumpToFile}>
+                <dc.SpanEmbed path={path} start={start} end={end} showExplain={false} />
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
埋め込み部分のチェックボックスを押したときは本来のトグル機能が行われファイルへのジャンプをしないようにしている
やり方としては、子要素の`<dc.SpanEmbed />`内でバブリングをしないようにできるならその方がいいと思うんやけど、
自分が管理するファイルじゃないのでイベントの発生源をチェックし、もしチェックボックスからのイベントなら処理を中断するように実装した。