### PR TITLE
update: ビューをより視覚的にわかりやすいようになるようヘッダーを調整

### DIFF
--- a/src/personal_views/components/personalized-embed.jsx
+++ b/src/personal_views/components/personalized-embed.jsx
@@ -58,10 +58,10 @@ export function PersonalizedPageEmbed(element) {
     return (
         <div className="personalized-embed" key={uuid}>
             <div className="personalized-embed-header">
-                <h2 onClick={jumpToFile}>
+                <h5 onClick={jumpToFile}>
                     <span className="date">{created.toFormat("MM/dd")} </span>
                     <span className="time">{created.toFormat("HH:mm:ss")}</span>
-                </h2>
+                </h5>
                 <fieldset>
                     {STATUS_OPTIONS.map(({ value, label }) => (
                         <dc.preact.Fragment key={value}>

--- a/src/personal_views/task-list.jsx
+++ b/src/personal_views/task-list.jsx
@@ -26,10 +26,10 @@ export function View() {
         const { key, rows } = group;
         return (
             <div key={key}>
-                <h2>
+                <h3>
                     {key.toUpperCase()}
                     {option.label}
-                </h2>
+                </h3>
                 <dc.List rows={rows} type="block" renderer={PersonalizedPageEmbed} />
             </div>
         );


### PR DESCRIPTION
本来は意味的に正しいヘッダーを使ってスタイルシートを用いて視覚的な調整をすべきだが、現時点でカスタムスタイルシートを作成しておらず、この変更のためにスタイルシートを作成するのは手間だと考えた。 そこで応急処置的に既存のスタイルでいい感じの表示がされるヘッダーを当てるようにした。