### PR TITLE
update: コンポーネント内の処理で必要な日付を引数から取得する

### DIFF
--- a/src/personal_views/task-list.jsx
+++ b/src/personal_views/task-list.jsx
@@ -3,7 +3,7 @@ import { STATUS_OPTIONS } from "./constants/status-options";
 
 const HIDE_DONE_SECTION = true;
 
-export function TaskList(date) {
+export function TaskList({ date }) {
     const query = `
         @page 
         and created >= date(${date}) - dur(6d) 

--- a/src/personal_views/task-list.jsx
+++ b/src/personal_views/task-list.jsx
@@ -3,13 +3,11 @@ import { STATUS_OPTIONS } from "./constants/status-options";
 
 const HIDE_DONE_SECTION = true;
 
-export function TaskList() {
-    const currentFile = dc.useCurrentFile();
-    const today = currentFile.$name;
+export function TaskList(date) {
     const query = `
         @page 
-        and created >= date(${today}) - dur(6d) 
-        and created < date(${today}) + dur(1d)
+        and created >= date(${date}) - dur(6d) 
+        and created < date(${date}) + dur(1d)
         and exists(status)
         and status != "tweet"`;
     const data = dc.useQuery(query);

--- a/src/personal_views/timeline.jsx
+++ b/src/personal_views/timeline.jsx
@@ -1,6 +1,6 @@
 import { PersonalizedPageEmbed } from "./components/personalized-embed";
 
-export function Timeline(date) {
+export function Timeline({ date }) {
     const data = dc.useQuery(`@page and path("tweets/${date}")`);
     const sorted = dc.useArray(data, (data) => data.sort((e) => e.value("created")));
     return <dc.List rows={sorted} type="block" renderer={PersonalizedPageEmbed} />;

--- a/src/personal_views/timeline.jsx
+++ b/src/personal_views/timeline.jsx
@@ -1,9 +1,7 @@
 import { PersonalizedPageEmbed } from "./components/personalized-embed";
 
-export function Timeline() {
-    const currentFile = dc.useCurrentFile();
-    const today = currentFile.$name;
-    const data = dc.useQuery(`@page and path("tweets/${today}")`);
+export function Timeline(date) {
+    const data = dc.useQuery(`@page and path("tweets/${date}")`);
     const sorted = dc.useArray(data, (data) => data.sort((e) => e.value("created")));
     return <dc.List rows={sorted} type="block" renderer={PersonalizedPageEmbed} />;
 }


### PR DESCRIPTION
以前はコンポーネント内の処理で必要な日付をコンポーネント内で導出していた。
これは副作用に違いなく望ましくないものとは考えていたが、このコンポーネントを用いるスニペット内で日付を導出しこのコンポーネントに引数として渡すのは別の拡張機能を入れなければいけないと思い込んでいた。 そのことによりメンテナンス性がむしろ悪化してしまうことを懸念したのでコンポーネント内で日付の導出を行っていた。 今改めて考えるとそのスニペット内で日付を導出するのは全く難しくないとなったので、副作用のある日付の導出作業を削除した。